### PR TITLE
Added local time to Israel

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import urllib.parse
 import re
 import requests
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 import db
 import functions
@@ -108,7 +109,7 @@ async def get_ctf(ctx):
         for i in range(5):
             dt_str = events[i]['start']
             dt = datetime.fromisoformat(dt_str)
-            dt_local = dt.astimezone()
+            dt_local = dt.astimezone(ZoneInfo("Asia/Jerusalem"))
             formatted_dt = dt_local.strftime("%Y-%m-%d - %H:%M")
             events_tostring += f"{i+1}. "
             events_tostring += f"**{events[i]['title']}**: "


### PR DESCRIPTION
Using zoneinfo, a standard library package, you can change the timezone of datetime objects to your selected timezone, the only requirement is to install the tzdata first party package from pipy using `pip install tzdata`  
docs: https://docs.python.org/3/library/zoneinfo.html#module-zoneinfo